### PR TITLE
feat(verses): expose all editable fields in update and get

### DIFF
--- a/src/commands/verses.js
+++ b/src/commands/verses.js
@@ -76,9 +76,17 @@ function registerVerses(program) {
       console.log(`title:         ${v.title}`);
       console.log(`description:   ${v.description || ''}`);
       console.log(`shortDesc:     ${v.shortDescription || ''}`);
+      console.log(`category:      ${v.category || ''}`);
+      console.log(`tags:          ${(v.tag || []).join(', ')}`);
       console.log(`visibility:    ${v.visibility}`);
       console.log(`featured:      ${v.featured}`);
       console.log(`showcase:      ${v.showcase}`);
+      console.log(`mobileFeatured:${v.mobileFeatured}`);
+      console.log(`allowRemix:    ${v.allowRemix}`);
+      console.log(`mobileSupport: ${v.isMobileSupported}`);
+      console.log(`imageUrl:      ${v.imageUrl || ''}`);
+      console.log(`coverImageUrl: ${v.coverImageUrl || ''}`);
+      console.log(`videoUrl:      ${v.videoUrl || ''}`);
       console.log(`creator:       ${v.creatorName || v.creatorHandle || 'n/a'}`);
       console.log(`created:       ${v.createdAt ? v.createdAt.slice(0, 10) : 'n/a'}`);
     });
@@ -88,10 +96,19 @@ function registerVerses(program) {
     .description('Update verse admin fields')
     .option('--featured <bool>', 'set featured')
     .option('--showcase <bool>', 'set showcase')
+    .option('--mobile-featured <bool>', 'set mobile featured')
     .option('--hidden <bool>', 'hide from recommendations')
     .option('--visibility <v>', 'public|unlisted|private')
+    .option('--title <text>', 'set verse title')
     .option('--description <text>', 'set verse description')
     .option('--short-description <text>', 'set verse short description')
+    .option('--category <text>', 'set verse category')
+    .option('--tags <tags>', 'set verse tags (comma-separated)')
+    .option('--allow-remix <bool>', 'allow remix')
+    .option('--mobile-supported <bool>', 'set mobile supported')
+    .option('--image-url <url>', 'set thumbnail image URL')
+    .option('--cover-image-url <url>', 'set cover image URL')
+    .option('--video-url <url>', 'set video URL')
     .action(async function (verseId) {
       const config = this.parent.parent._v8config;
       requireToken(config);
@@ -100,11 +117,20 @@ function registerVerses(program) {
       const body = {};
       if (opts.featured !== undefined) body.featured = opts.featured === 'true';
       if (opts.showcase !== undefined) body.showcase = opts.showcase === 'true';
+      if (opts.mobileFeatured !== undefined) body.mobileFeatured = opts.mobileFeatured === 'true';
       if (opts.hidden !== undefined) body.isHiddenFromRecommendation = opts.hidden === 'true';
       if (opts.visibility) body.visibility = opts.visibility;
+      if (opts.title !== undefined) body.title = opts.title;
       if (opts.description !== undefined) body.description = opts.description;
       if (opts.shortDescription !== undefined) body.shortDescription = opts.shortDescription;
-      if (Object.keys(body).length === 0) return err('No fields to update. Use --featured, --showcase, --hidden, --visibility, --description, or --short-description');
+      if (opts.category !== undefined) body.category = opts.category;
+      if (opts.tags !== undefined) body.tag = opts.tags.split(',').map((t) => t.trim());
+      if (opts.allowRemix !== undefined) body.allowRemix = opts.allowRemix === 'true';
+      if (opts.mobileSupported !== undefined) body.isMobileSupported = opts.mobileSupported === 'true';
+      if (opts.imageUrl !== undefined) body.imageUrl = opts.imageUrl;
+      if (opts.coverImageUrl !== undefined) body.coverImageUrl = opts.coverImageUrl;
+      if (opts.videoUrl !== undefined) body.videoUrl = opts.videoUrl;
+      if (Object.keys(body).length === 0) return err('No fields to update. Use --help to see available options.');
       const res = await post(base, `/v1/admin/verse/${encodeURIComponent(verseId)}`, config.token, body);
       if (res.status !== 200 && res.status !== 201) return err(`${res.status}: ${res.data.message || 'failed'}`);
       ok(`Verse ${verseId} updated: ${JSON.stringify(body)}`);

--- a/src/commands/verses.js
+++ b/src/commands/verses.js
@@ -71,14 +71,16 @@ function registerVerses(program) {
       if (res.status !== 200) return err(`${res.status}: ${res.data.message || 'failed'}`);
       if (this.parent.parent.opts().json) return console.log(JSON.stringify(res.data));
       const v = res.data;
-      console.log(`id:         ${v.verseId}`);
-      console.log(`shortId:    ${v.verseShortId || v.shortId}`);
-      console.log(`title:      ${v.title}`);
-      console.log(`visibility: ${v.visibility}`);
-      console.log(`featured:   ${v.featured}`);
-      console.log(`showcase:   ${v.showcase}`);
-      console.log(`creator:    ${v.creatorName || v.creatorHandle || 'n/a'}`);
-      console.log(`created:    ${v.createdAt ? v.createdAt.slice(0, 10) : 'n/a'}`);
+      console.log(`id:            ${v.verseId}`);
+      console.log(`shortId:       ${v.verseShortId || v.shortId}`);
+      console.log(`title:         ${v.title}`);
+      console.log(`description:   ${v.description || ''}`);
+      console.log(`shortDesc:     ${v.shortDescription || ''}`);
+      console.log(`visibility:    ${v.visibility}`);
+      console.log(`featured:      ${v.featured}`);
+      console.log(`showcase:      ${v.showcase}`);
+      console.log(`creator:       ${v.creatorName || v.creatorHandle || 'n/a'}`);
+      console.log(`created:       ${v.createdAt ? v.createdAt.slice(0, 10) : 'n/a'}`);
     });
 
   cmd
@@ -88,6 +90,8 @@ function registerVerses(program) {
     .option('--showcase <bool>', 'set showcase')
     .option('--hidden <bool>', 'hide from recommendations')
     .option('--visibility <v>', 'public|unlisted|private')
+    .option('--description <text>', 'set verse description')
+    .option('--short-description <text>', 'set verse short description')
     .action(async function (verseId) {
       const config = this.parent.parent._v8config;
       requireToken(config);
@@ -98,7 +102,9 @@ function registerVerses(program) {
       if (opts.showcase !== undefined) body.showcase = opts.showcase === 'true';
       if (opts.hidden !== undefined) body.isHiddenFromRecommendation = opts.hidden === 'true';
       if (opts.visibility) body.visibility = opts.visibility;
-      if (Object.keys(body).length === 0) return err('No fields to update. Use --featured, --showcase, --hidden, or --visibility');
+      if (opts.description !== undefined) body.description = opts.description;
+      if (opts.shortDescription !== undefined) body.shortDescription = opts.shortDescription;
+      if (Object.keys(body).length === 0) return err('No fields to update. Use --featured, --showcase, --hidden, --visibility, --description, or --short-description');
       const res = await post(base, `/v1/admin/verse/${encodeURIComponent(verseId)}`, config.token, body);
       if (res.status !== 200 && res.status !== 201) return err(`${res.status}: ${res.data.message || 'failed'}`);
       ok(`Verse ${verseId} updated: ${JSON.stringify(body)}`);


### PR DESCRIPTION
## Summary

Exposes all editable verse fields via `v8 verses update`, and adds the same fields to `v8 verses get` output.

## Changes

### `verses update` — new options
| Option | Description |
|---|---|
| `--title <text>` | Set verse title |
| `--description <text>` | Set verse description |
| `--short-description <text>` | Set verse short description |
| `--category <text>` | Set verse category |
| `--tags <tags>` | Set tags (comma-separated) |
| `--allow-remix <bool>` | Allow remix |
| `--mobile-supported <bool>` | Set mobile supported |
| `--mobile-featured <bool>` | Set mobile featured |
| `--image-url <url>` | Set thumbnail image URL |
| `--cover-image-url <url>` | Set cover image URL |
| `--video-url <url>` | Set video URL |

### `verses get` — additional fields displayed
category, tags, mobileFeatured, allowRemix, isMobileSupported, imageUrl, coverImageUrl, videoUrl

## Why

The underlying API already accepts all these fields. Exposing them via CLI makes admin operations much easier — no more raw `curl` calls needed.

Closes #8