### PR TITLE
Add usage tracking for command promotion

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -97,8 +97,16 @@ To propose a new workflow for the shared CLI, run:
 
 See `references/admin-api.md` for full endpoint details (useful when CLI doesn't cover an edge case).
 
+## Command Promotion
+
+Auto-generated commands (`game-payments`, `analytics`, `missions`, `verse-tags`) output raw JSON.
+If a gen-* command's output is repeatedly inconvenient (too verbose, needs formatting), check `v8 usage` for frequency. If a command has 5+ uses, consider promoting it to a hand-written version with formatted table output:
+
+`gh issue create --repo planetarium/v8-cli --title "promote: <command>" --label quick-fix`
+
 ## Notes
 
 - Credit amounts in `credits give` are in USD (e.g. `20` = $20)
 - Comment search requires `--by` and keyword together
 - `--json` flag outputs raw API response for piping or debugging
+- `v8 usage` shows command usage stats

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const { registerCoupons } = require('./commands/coupons');
 const { registerVerses } = require('./commands/verses');
 const { registerAuth } = require('./commands/auth');
 const { registerConfig } = require('./commands/config-cmd');
+const { track, report } = require('./usage');
 const { registerGamePayments } = require('./commands/gen-game-payments');
 const { registerVerseTags } = require('./commands/gen-verse-tags');
 const { registerMissions } = require('./commands/gen-missions');
@@ -22,15 +23,27 @@ program
   .option('--env <env>', 'environment (test|local)')
   .option('--token <jwt>', 'bearer token override')
   .option('--json', 'output raw JSON')
-  .hook('preAction', (thisCommand) => {
-    const opts = thisCommand.optsWithGlobals();
+  .hook('preAction', (thisCommand, actionCommand) => {
+    const target = actionCommand || thisCommand;
+    const opts = target.optsWithGlobals();
     const config = loadConfig();
     if (opts.env) config.env = opts.env;
     if (opts.token) config.token = opts.token;
-    thisCommand._v8config = config;
+    target._v8config = config;
+    // Also set on thisCommand for compatibility
+    if (target !== thisCommand) thisCommand._v8config = config;
+    // Track usage: "parent subcommand" e.g. "comments list"
+    const parts = [];
+    let cmd = target;
+    while (cmd && cmd.name() !== 'v8') {
+      parts.unshift(cmd.name());
+      cmd = cmd.parent;
+    }
+    if (parts.length > 0 && parts[0] !== 'usage') track(parts.join(' '));
   });
 
 registerConfig(program);
+program.command('usage').description('Show command usage stats').action(report);
 registerAuth(program);
 registerUsers(program);
 registerCredits(program);

--- a/src/usage.js
+++ b/src/usage.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const USAGE_FILE = path.join(process.env.HOME || '', '.config', 'v8-cli', 'usage.json');
+
+function load() {
+  try {
+    return JSON.parse(fs.readFileSync(USAGE_FILE, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function track(commandName) {
+  const data = load();
+  data[commandName] = (data[commandName] || 0) + 1;
+  fs.mkdirSync(path.dirname(USAGE_FILE), { recursive: true });
+  fs.writeFileSync(USAGE_FILE, JSON.stringify(data, null, 2) + '\n');
+}
+
+function report() {
+  const data = load();
+  const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) {
+    console.log('(no usage data)');
+    return;
+  }
+  const maxCmd = Math.max(...entries.map(([k]) => k.length), 7);
+  console.log('Command'.padEnd(maxCmd) + '  Count');
+  console.log('-'.repeat(maxCmd) + '  -----');
+  for (const [cmd, count] of entries) {
+    console.log(cmd.padEnd(maxCmd) + '  ' + count);
+  }
+}
+
+module.exports = { track, report, USAGE_FILE };


### PR DESCRIPTION
## Summary
- `v8 usage` 커맨드로 사용 빈도 확인
- gen-* 커맨드가 5회 이상 사용되면 hand-written 버전으로 승격 제안하도록 스킬에 가이드 추가
- 사용 데이터는 `~/.config/v8-cli/usage.json`에 저장

## Example
```
$ v8 usage
Command        Count
-------------  -----
auth           12
comments list  8
game-payments list  6   ← 승격 후보
```

## Test plan
- [ ] `v8 auth` → `v8 usage`에서 카운트 1 확인
- [ ] `v8 comments list --limit 1` → 카운트 증가 확인
- [ ] `v8 usage` 자체는 카운트에 안 잡히는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)